### PR TITLE
Mumble Updates

### DIFF
--- a/brave/mumble/auth/model.py
+++ b/brave/mumble/auth/model.py
@@ -90,6 +90,7 @@ class Ticket(Document):
     
     expires = DateTimeField(db_field='e')
     seen = DateTimeField(db_field='s')  # TODO: Update this when the user connects/disconnects.
+    updated = DateTimeField(db_field='s')
     registered = DateTimeField(db_field='r')
     
     @property
@@ -132,6 +133,7 @@ class Ticket(Document):
                 user.alliance.ticker = alliance.short
         
         user.tags = [i.replace('mumble.', '') for i in (result.tags if 'tags' in result else [])]
+        user.updated = datetime.now()
         user.save()
         
         return user.id, user

--- a/brave/mumble/auth/model.py
+++ b/brave/mumble/auth/model.py
@@ -90,7 +90,7 @@ class Ticket(Document):
     
     expires = DateTimeField(db_field='e')
     seen = DateTimeField(db_field='s')  # TODO: Update this when the user connects/disconnects.
-    updated = DateTimeField(db_field='s')
+    updated = DateTimeField(db_field='u')
     registered = DateTimeField(db_field='r')
     
     @property

--- a/brave/mumble/service.py
+++ b/brave/mumble/service.py
@@ -121,7 +121,11 @@ class MumbleAuthenticator(Murmur.ServerUpdatingAuthenticator):
             log.warn('pass-fail "%s"', name)
             return AUTH_FAIL
         
-        if user.updated > (datetime.now() - timedelta(days = 2))
+        ticketUpdateTimeoutHours = 48
+        if config['mumble.ticketUpdateTimeoutHours']
+            ticketUpdateTimeoutHours = int(config['mumble.ticketUpdateTimeoutHours']) # exception will happen here if your bad
+        
+        if user.updated > (datetime.now() - timedelta(hours = ticketUpdateTimeoutHours))
             # -------
             # Check to make sure that the user is still valid and that their token has not expired yet.
             # -------

--- a/brave/mumble/service.py
+++ b/brave/mumble/service.py
@@ -13,6 +13,7 @@ from web.core import config
 from marrow.util.convert import number, array
 from marrow.util.bunch import Bunch
 from collections import defaultdict
+from datetime import datetime, timedelta
 
 from brave.mumble.auth.model import Ticket
 from brave.api.client import API
@@ -120,7 +121,7 @@ class MumbleAuthenticator(Murmur.ServerUpdatingAuthenticator):
             log.warn('pass-fail "%s"', name)
             return AUTH_FAIL
         
-        if user.seen > (datetime.now() - timedelta(days = 2))
+        if user.updated > (datetime.now() - timedelta(days = 2))
             # -------
             # Check to make sure that the user is still valid and that their token has not expired yet.
             # -------

--- a/brave/mumble/service.py
+++ b/brave/mumble/service.py
@@ -103,7 +103,7 @@ class MumbleAuthenticator(Murmur.ServerUpdatingAuthenticator):
         
         # Look up the user.
         try:
-            user = Ticket.objects.only('tags', 'seen', 'password', 'corporation__id', 'alliance__id', 'alliance__ticker', 'character__id', 'token').get(character__name=name)
+            user = Ticket.objects.only('tags', 'updated', 'password', 'corporation__id', 'alliance__id', 'alliance__ticker', 'character__id', 'token').get(character__name=name)
         except Ticket.DoesNotExist:
             log.warn('User "%s" not found in the Ticket database.', name)
             return AUTH_FAIL
@@ -122,10 +122,10 @@ class MumbleAuthenticator(Murmur.ServerUpdatingAuthenticator):
             return AUTH_FAIL
         
         ticketUpdateTimeoutHours = 48
-        if config['mumble.ticketUpdateTimeoutHours']
+        if config['mumble.ticketUpdateTimeoutHours']:
             ticketUpdateTimeoutHours = int(config['mumble.ticketUpdateTimeoutHours']) # exception will happen here if your bad
         
-        if user.updated > (datetime.now() - timedelta(hours = ticketUpdateTimeoutHours))
+        if user.updated > (datetime.now() - timedelta(hours = ticketUpdateTimeoutHours)):
             # -------
             # Check to make sure that the user is still valid and that their token has not expired yet.
             # -------
@@ -133,7 +133,7 @@ class MumbleAuthenticator(Murmur.ServerUpdatingAuthenticator):
             # load up the API
             api = API(config['api.endpoint'], config['api.identity'], config['api.private'], config['api.public'])
             
-            # is mumble set to just use the main ticket DB if
+            # is mumble set to just use the main ticket DB if core cant be contacted?
             config_bypass_core = config['mumble.bypassCore'] == 'True' or config['mumble.bypassCore'] == 'true'
             
             try:
@@ -145,7 +145,7 @@ class MumbleAuthenticator(Murmur.ServerUpdatingAuthenticator):
                 return AUTH_FAIL
                 
             # Update the local user object against the newly refreshed DB ticket.
-            user = Ticket.objects.only('tags', 'seen', 'password', 'corporation__id', 'alliance__id', 'alliance__ticker', 'character__id', 'token').get(character__name=name)
+            user = Ticket.objects.only('tags', 'updated', 'password', 'corporation__id', 'alliance__id', 'alliance__ticker', 'character__id', 'token').get(character__name=name)
             
             # Define the registration date if one has not been set.
             Ticket.objects(character__name=name, registered=None).update(set__registered=datetime.datetime.utcnow())

--- a/brave/mumble/service.py
+++ b/brave/mumble/service.py
@@ -102,7 +102,7 @@ class MumbleAuthenticator(Murmur.ServerUpdatingAuthenticator):
         
         # Look up the user.
         try:
-            user = Ticket.objects.only('tags', 'password', 'corporation__id', 'alliance__id', 'alliance__ticker', 'character__id', 'token').get(character__name=name)
+            user = Ticket.objects.only('tags', 'seen', 'password', 'corporation__id', 'alliance__id', 'alliance__ticker', 'character__id', 'token').get(character__name=name)
         except Ticket.DoesNotExist:
             log.warn('User "%s" not found in the Ticket database.', name)
             return AUTH_FAIL
@@ -120,32 +120,30 @@ class MumbleAuthenticator(Murmur.ServerUpdatingAuthenticator):
             log.warn('pass-fail "%s"', name)
             return AUTH_FAIL
         
-        # Check that Core is up.
-        api = API(config['api.endpoint'], config['api.identity'], config['api.private'], config['api.public'])
-        try:
-            api.ping()
-            ping = True
-        except Exception:
-            ping = False
-            log.warning('Unable to connect to core!.')
-        
-        configV = config['mumble.bypassCore'] == 'True' or config['mumble.bypassCore'] == 'true'
-        
-        allow = ping or configV
-        
-        try:
-            # If the token is not valid, deny access
-            if not allow or (ping and not Ticket.authenticate(user.token)):
-                return AUTH_FAIL
-        except Exception as e:
-            log.warning("Exception occured when attempting to authenticate user {0}.".format(name))
-            return AUTH_FAIL
+        if user.seen > (datetime.now() - timedelta(days = 2))
+            # -------
+            # Check to make sure that the user is still valid and that their token has not expired yet.
+            # -------
             
-        # Update the local user object against the newly refreshed DB ticket.
-        user = Ticket.objects.only('tags', 'password', 'corporation__id', 'alliance__id', 'alliance__ticker', 'character__id', 'token').get(character__name=name)
-        
-        # Define the registration date if one has not been set.
-        Ticket.objects(character__name=name, registered=None).update(set__registered=datetime.datetime.utcnow())
+            # load up the API
+            api = API(config['api.endpoint'], config['api.identity'], config['api.private'], config['api.public'])
+            
+            # is mumble set to just use the main ticket DB if
+            config_bypass_core = config['mumble.bypassCore'] == 'True' or config['mumble.bypassCore'] == 'true'
+            
+            try:
+                # If the token is not valid, deny access
+                if not config_bypass_core and not Ticket.authenticate(user.token):
+                    return AUTH_FAIL
+            except Exception as e:
+                log.warning("Exception occured when attempting to authenticate user {0}.".format(name))
+                return AUTH_FAIL
+                
+            # Update the local user object against the newly refreshed DB ticket.
+            user = Ticket.objects.only('tags', 'seen', 'password', 'corporation__id', 'alliance__id', 'alliance__ticker', 'character__id', 'token').get(character__name=name)
+            
+            # Define the registration date if one has not been set.
+            Ticket.objects(character__name=name, registered=None).update(set__registered=datetime.datetime.utcnow())
         
         for tag in ('member', 'blue', 'guest', 'mumble'):
             if tag in user.tags: break

--- a/development.ini
+++ b/development.ini
@@ -64,6 +64,8 @@ idle.groups = general
 # Have mumble fall back to it's database when the connection to Core is interrupted.
 mumble.bypassCore =  False
 
+mumble.ticketUpdateTimeoutHours = 48
+
 [loggers]
 keys = root, app, webcore
 


### PR DESCRIPTION
Remove Ping call
Update Model with new 'updated' property that is set when the token is accessed on api.core.info()
Update service to only check with core for user access on a deployment configurable timeout
