### PR TITLE
Display a user's leadership status when they're logged in.

### DIFF
--- a/brave/mumble/service.py
+++ b/brave/mumble/service.py
@@ -167,6 +167,24 @@ class MumbleAuthenticator(Murmur.ServerUpdatingAuthenticator):
             log.debug('success "%s" %s', name, ' '.join(tags))
         
             ticker = user.alliance.ticker if user.alliance.ticker else '----'
+            
+            rank = ''
+        
+            for t in ['admin', 'supercommand', 'moderator', 'diplo', 'brass', 'fc', 'fc.trial', 'fc.guest', 'dojo']:
+                if t in tags:
+                    rank = t
+                    # Because moderator is long and supercommand is a dumb group name
+                    if rank == 'supercommand':
+                        rank = 'SuperMod'
+                        break
+                    if rank == 'moderator':
+                        rank = 'mod'
+                    rank = rank.capitalize()
+                    break
+            
+            if rank:
+                return (user.character.id, '[{0}] {1} ({2})'.format(ticker, name, rank), tags)
+                
             return (user.character.id, '[{0}] {1}'.format(ticker, name), tags)
             
         except Exception as exc:


### PR DESCRIPTION
"IT: is there a way to have icons in mumble for leadership?
FC in brackets or something" - CNM 06/22/14

The one non-redacted thing : P

Signed-off-by: Tyler O'Meara Tyler@TylerOMeara.com
