### PR TITLE
Fix a bug in __call__ in the IdlerHandler that was preventing the...

### DIFF
--- a/brave/mumble/service.py
+++ b/brave/mumble/service.py
@@ -67,6 +67,10 @@ class IdlerHandler(object):
         map = self.map
         
         for user in users:
+            if isinstance(user, int):
+                log.debug("Apprently users are integers. That's cool I guess. {0}".format(user))
+                continue
+            
             if user.channel in exclude: continue
             
             try:


### PR DESCRIPTION
...authenticator from attaching to a mumble server that had users logged in.

Signed-off-by: Tyler O'Meara Tyler@TylerOMeara.com
